### PR TITLE
Add `/friendplaytime` command with autocomplete and private responses

### DIFF
--- a/genbot/src/main/java/com/genetiicz/genbot/commands/SlashCommandRegister.java
+++ b/genbot/src/main/java/com/genetiicz/genbot/commands/SlashCommandRegister.java
@@ -4,6 +4,7 @@ import jakarta.annotation.PostConstruct;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,10 +22,19 @@ public class SlashCommandRegister {
         jda.updateCommands().addCommands(
                 Commands.slash("myplaytime", "See how long you have been playing the game in **total**.")
                         .addOption(OptionType.STRING, "game", "Name of the game", true,true),
+
                  Commands.slash("leaderboard", "See top 3 most active players in this **game**.")
-                         .addOption(OptionType.STRING, "game", "Name of the game", true,true) //we want autocomplete on this one.
+                         .addOption(OptionType.STRING, "game", "Name of the game", true,true), //we want autocomplete on this one.
+
+                Commands.slash("friendplaytime", "See your friend's global playtime! NB: **Both needs to be on the same server**")
+                        .addOption(OptionType.USER, "friend", "Select or type the user", true)
+                        .addOptions(gameOption())
         ).queue();
 
-        System.out.println("Slash commands 'myplaytime' and 'leaderboard 'is registered!");
+        System.out.println("Slash commands 'myplaytime','leaderboard' and 'friendplaytime' is registered!");
+    }
+
+    private OptionData gameOption() {
+        return new OptionData(OptionType.STRING, "game", "name of the game").setRequired(true).setAutoComplete(true);
     }
 }

--- a/genbot/src/main/java/com/genetiicz/genbot/database/repository/PlayTimeRepository.java
+++ b/genbot/src/main/java/com/genetiicz/genbot/database/repository/PlayTimeRepository.java
@@ -57,4 +57,7 @@ public interface PlayTimeRepository extends JpaRepository<PlayTimeEntity, Long> 
             @Param("userId") String userId,
             @Param("serverId") String serverId
     );
+
+    //fetching friend's specific game entry on the server both are in
+    Optional<PlayTimeEntity> findByUserIdAndGameNameAndServerId (String userId, String gameName, String serverId);
 }

--- a/genbot/src/main/java/com/genetiicz/genbot/database/repository/SlashRepository.java
+++ b/genbot/src/main/java/com/genetiicz/genbot/database/repository/SlashRepository.java
@@ -2,16 +2,13 @@ package com.genetiicz.genbot.database.repository;
 
 import com.genetiicz.genbot.database.entity.PlayTimeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
 //We make a new repository so we have seperation of concerns
 //Ideally for having a clean architecture and understanding of project
 
 @Repository
 public interface SlashRepository extends JpaRepository<PlayTimeEntity,Long> {
-    Optional<PlayTimeEntity> findByUserIdAndGameName (String userId,String gameName);
-    Optional<PlayTimeEntity> findTopByUserIdAndGameNameIgnoreCase (String userId, String gameName);
+
 }

--- a/genbot/src/main/java/com/genetiicz/genbot/listener/SlashCommandListener.java
+++ b/genbot/src/main/java/com/genetiicz/genbot/listener/SlashCommandListener.java
@@ -8,14 +8,13 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Consumer;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 @Service
@@ -37,9 +36,13 @@ public class SlashCommandListener extends ListenerAdapter {
         //handler with the methods of replyWithPlaytime
         //it is supposed to tell the user if the user does not have any games on the server recorded.
         handlers.put("myplaytime", slashService::replyWithPlaytime);
+
         //here we can add more handlers.put for several commands for the bot.
         //Since this worked, now we implement Top5 command inside the handler
         handlers.put("leaderboard", slashService::replyWithPlaytimeTop3);
+
+        //implementing to check friends game time in the same server.
+        handlers.put("friendplaytime", slashService::replyWithFriendTime);
     }
 
     @Override
@@ -73,6 +76,15 @@ public class SlashCommandListener extends ListenerAdapter {
         List<String> gameSuggestions;  // we want do display max 10 choices, discord has 25 general choices.
             if(commandName.equals("myplaytime")) {
                 gameSuggestions = playTimeService.getMatchingGamesForUserStartingWith(input,serverId,userId,10);
+
+            } else if (commandName.equals("friendplaytime")) {
+                var friendOpt = event.getOption("friend");
+                if (friendOpt == null) {
+                    event.replyChoices(Collections.emptyList()).queue();
+                    return;
+                }
+                String friendId = friendOpt.getAsString();
+                gameSuggestions = playTimeService.getMatchingGamesForUserStartingWith(input, serverId,friendId , 10);
             } else {
                 gameSuggestions = playTimeService.getMatchingGamesStartingWith(input,serverId,10);
             }
@@ -83,7 +95,7 @@ public class SlashCommandListener extends ListenerAdapter {
             choices.add(choice);
         }
         //Reply with choices
-        if(commandName.equals("leaderboard") || commandName.equals("myplaytime")){
+        if(commandName.equals("leaderboard") || commandName.equals("myplaytime") || commandName.equals("friendplaytime")){
             event.replyChoices(choices).queue();
         }
     }

--- a/genbot/src/main/java/com/genetiicz/genbot/service/PlayTimeService.java
+++ b/genbot/src/main/java/com/genetiicz/genbot/service/PlayTimeService.java
@@ -4,6 +4,8 @@ import com.genetiicz.genbot.database.entity.PlayTimeEntity;
 import com.genetiicz.genbot.database.entity.PlayTimeServerEntity;
 import com.genetiicz.genbot.database.repository.PlayTimeRepository;
 import com.genetiicz.genbot.database.repository.PlayTimeServerRepository;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -183,5 +185,10 @@ public class PlayTimeService {
     public List<String> getMatchingGamesForUserStartingWith(String input, String serverId, String userId, int limit) {
         return playTimeServerRepository
                 .findDistinctGameNamesByUserIdAndServerIdIgnoreCase(input, serverId, userId, PageRequest.of(0, limit));
+    }
+
+    //Find the friends global playtime for the game - or empty if nothing
+    public Optional<Long> getFriendTotalMinutes (String friendId, String gameName, String serverId) {
+        return playTimeRepository.findByUserIdAndGameNameAndServerId(friendId, gameName,serverId).map(PlayTimeEntity::getTotalMinutesPlayed);
     }
 }


### PR DESCRIPTION
- Registered `friendplaytime` slash command (USER + game options)
- Wired up handler in `SlashCommandListener` and `SlashService`
- Enhanced autocomplete to suggest games for the selected friend
- Fixed repo/query order and service method signature for user/game/server lookup
- Ensured all replies are ephemeral so only the invoker sees them