### PR TITLE
Global checking for friend also -  don

### DIFF
--- a/genbot/src/main/java/com/genetiicz/genbot/database/repository/PlayTimeRepository.java
+++ b/genbot/src/main/java/com/genetiicz/genbot/database/repository/PlayTimeRepository.java
@@ -57,7 +57,4 @@ public interface PlayTimeRepository extends JpaRepository<PlayTimeEntity, Long> 
             @Param("userId") String userId,
             @Param("serverId") String serverId
     );
-
-    //fetching friend's specific game entry on the server both are in
-    Optional<PlayTimeEntity> findByUserIdAndGameNameAndServerId (String userId, String gameName, String serverId);
 }

--- a/genbot/src/main/java/com/genetiicz/genbot/service/PlayTimeService.java
+++ b/genbot/src/main/java/com/genetiicz/genbot/service/PlayTimeService.java
@@ -163,7 +163,7 @@ public class PlayTimeService {
     }
 
     //Find the friends global playtime for the game - or empty if nothing
-    public Optional<Long> getFriendTotalMinutes (String friendId, String gameName, String serverId) {
-        return playTimeRepository.findByUserIdAndGameNameAndServerId(friendId, gameName,serverId).map(PlayTimeEntity::getTotalMinutesPlayed);
+    public Optional<Long> getFriendTotalMinutes (String friendId, String gameName) {
+        return playTimeRepository.findByUserIdAndGameNameIgnoreCase(friendId, gameName).map(PlayTimeEntity::getTotalMinutesPlayed);
     }
 }

--- a/genbot/src/main/java/com/genetiicz/genbot/service/SlashService.java
+++ b/genbot/src/main/java/com/genetiicz/genbot/service/SlashService.java
@@ -202,7 +202,7 @@ public class SlashService {
         String serverId = event.getGuild().getId();
         String gameName = event.getOption("game").getAsString();
 
-        Optional<Long> friendTime = playTimeService.getFriendTotalMinutes(friendId,gameName,serverId);
+        Optional<Long> friendTime = playTimeService.getFriendTotalMinutes(friendId,gameName);
         if(friendTime.isEmpty() || friendTime.get() == 0L){
             event.reply("No record playtime for friend: <@" + friendId + "> on **" + gameName + "**.")
                     .setEphemeral(true).queue();


### PR DESCRIPTION
…d anymore since everything is globally except for the leaderboards.

so if we want to check a friends playtime, we do it with just the userId and gameName -  drop the serverId.

I have another entity for storing the serverId and serverName if i should analyze the data.